### PR TITLE
Fix csv colorMap for map with offset values 

### DIFF
--- a/src/converters/CsvItem.ts
+++ b/src/converters/CsvItem.ts
@@ -172,9 +172,28 @@ function getColorTraits(tableStyle: PlainObject): ColorStyle | undefined {
   if (is.string(tableStyle.nullLabel)) color.nullLabel = tableStyle.nullLabel;
   if (is.number(tableStyle.colorBins))
     color.numberOfBins = tableStyle.colorBins;
+
+  /*  colorMap can be three things:
+   *  - String, eg. 'red-black'
+   *  - Array of strings, eg. ['red', 'black']
+   *  - Array of objects with the properties 'color' and 'offset', eg. [{color: 'red', offset: 0}, ...].
+   *    - v8 only supports array of strings, so 'offset' is discarded
+   */
   if (is.string(tableStyle.colorMap))
     color.binColors = tableStyle.colorMap.split("-");
-  if (is.array(tableStyle.colorMap)) color.binColors = tableStyle.colorMap;
+  if (is.array(tableStyle.colorMap)) {
+    if (typeof tableStyle.colorMap[0] == "string") {
+      color.binColors = tableStyle.colorMap;
+    } else {
+      color.binColors = tableStyle.colorMap.reduce<string[]>(
+        (binColors, current) =>
+          typeof current.color === "string"
+            ? binColors.concat(current.color)
+            : binColors,
+        []
+      );
+    }
+  }
   return is.emptyObject(color) ? undefined : color;
 }
 

--- a/src/converters/CsvItem.ts
+++ b/src/converters/CsvItem.ts
@@ -22,7 +22,7 @@ interface TableTraits {
 
 interface TableStyle {
   columns?: Column[];
-  styles?: ColorStyle[];
+  styles?: Style[];
   defaultColumn?: Omit<Column, "name">;
   defaultStyle?: Style;
   activeStyle?: string;
@@ -83,10 +83,11 @@ function tableStyle(tableStyle: PlainObject): TableTraits {
       .filter(([name, defn]) => is.plainObject(defn))
       .map(([name, defn]) => ({
         id: name,
-        ...getColorTraits(defn as PlainObject),
+        color: getColorTraits(defn as PlainObject),
+        time: getTimeTraits(defn as PlainObject),
       }))
       // Filter out styles which have no properties other than `id`
-      .filter((style) => Object.keys(style).length > 1);
+      .filter((style) => style.color || style.time);
 
     const chartLines = getChartLines(tableStyle.columns);
     if (chartLines) {

--- a/test/convertCatalog.test.ts
+++ b/test/convertCatalog.test.ts
@@ -147,6 +147,14 @@ describe("Test convertCatalog", () => {
     expect(res.messages).toHaveLength(0);
   });
 
+  it("converts the csv with styles", function () {
+    const v7 = require("./samples/v7/csv-styles.json");
+    const v8 = require("./samples/v8/csv-styles.json");
+    const res = convertCatalog(v7);
+    expect(res.result).toMatchObject(v8);
+    expect(res.messages).toHaveLength(0);
+  });
+
   it("adds shareKeys", function () {
     const v7 = require("./samples/v7/shareKeys.json");
     const v8 = require("./samples/v8/shareKeys.json");

--- a/test/samples/v7/csv-styles.json
+++ b/test/samples/v7/csv-styles.json
@@ -1,0 +1,80 @@
+{
+  "catalog": [
+    {
+      "type": "csv",
+      "url": "https://api.transport.nsw.gov.au/v1/roads/spatial?format=csv&q=%0A%20%20%20%20%20%20SELECT%0A%20%20%20%20%20%20%20%20REF.STATION_ID%2C%0A%20%20%20%20%20%20%20%20NAME%2C%0A%20%20%20%20%20%20%20%20LGA%2C%0A%20%20%20%20%20%20%20%20SUBURB%2C%0A%20%20%20%20%20%20%20%20CASE%20VEHICLE_CLASSIFIER%20WHEN%200%20THEN%20true%20ELSE%20false%20END%20AS%20HAS_VEHICLE_CLASSIFIER%2C%0A%20%20%20%20%20%20%20%20ROAD_FUNCTIONAL_HIERARCHY%20AS%20ROAD_TYPE%2C%0A%20%20%20%20%20%20%20%20WGS84_LATITUDE%20AS%20LATITUDE%2C%0A%20%20%20%20%20%20%20%20WGS84_LONGITUDE%20AS%20LONGITUDE%2C%0A%20%20%20%20%20%20%20%20YEAR%2C%0A%20%20%20%20%20%20%20%20CASE%0A%20%20%20%20%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'0'%20THEN%20'BOTH'%0A%20%20%20%20%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'1'%20THEN%20'NORTH'%0A%20%20%20%20%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'3'%20THEN%20'EAST'%0A%20%20%20%20%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'5'%20THEN%20'SOUTH'%0A%20%20%20%20%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'7'%20THEN%20'WEST'%0A%20%20%20%20%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'9'%20THEN%20'NORTH%20TO%20SOUTH'%0A%20%20%20%20%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'10'%20THEN%20'EAST%20TO%20WEST'%0A%20%20%20%20%20%20%20%20END%20AS%20PRIMARY_DIRECTION%2C%0A%20%20%20%20%20%20%20%20SUM(CASE%20CLASSIFICATION_TYPE%20WHEN%20'UNCLASSIFIED'%20THEN%20TRAFFIC_COUNT%20ELSE%200%20END)%20AS%20UNCLASSIFIED_COUNT%2C%0A%20%20%20%20%20%20%20%20SUM(CASE%20CLASSIFICATION_TYPE%20WHEN%20'ALL%20VEHICLES'%20THEN%20TRAFFIC_COUNT%20ELSE%200%20END)%20AS%20ALL_VEHICLES_COUNT%2C%0A%20%20%20%20%20%20%20%20SUM(CASE%20CLASSIFICATION_TYPE%20WHEN%20'LIGHT%20VEHICLES'%20THEN%20TRAFFIC_COUNT%20ELSE%200%20END)%20AS%20LIGHT_VEHICLES_COUNT%2C%0A%20%20%20%20%20%20%20%20SUM(CASE%20CLASSIFICATION_TYPE%20WHEN%20'HEAVY%20VEHICLES'%20THEN%20TRAFFIC_COUNT%20ELSE%200%20END)%20AS%20HEAVY_VEHICLES_COUNT%0A%20%20%20%20%20%20FROM%20road_traffic_counts_station_reference%20REF%0A%20%20%20%20%20%20JOIN%20road_traffic_counts_yearly_summary%20SUMM%20ON%20REF.STATION_KEY%3DSUMM.STATION_KEY%0A%20%20%20%20%20%20WHERE%20YEAR%20IN%20('2015'%2C'2016'%2C'2017'%2C'2018'%2C'2019')%0A%20%20%20%20%20%20%20%20AND%20PERIOD%3D'ALL%20DAYS'%0A%20%20%20%20%20%20%20%20AND%20TRAFFIC_DIRECTION_SEQ%20IN%20('0'%2C%20'1')%0A%20%20%20%20%20%20GROUP%20BY%20REF.STATION_ID%2CVEHICLE_CLASSIFIER%2CNAME%2CLGA%2CSUBURB%2CWGS84_LATITUDE%2CWGS84_LONGITUDE%2CYEAR%2CROAD_FUNCTIONAL_HIERARCHY%2CDIRECTION_SEQ%0A%20%20",
+      "name": "Average Daily Traffic Volume",
+      "tableStyle": {
+        "colorPalette": "YlOrBr",
+        "columns": {
+          "has_vehicle_classifier": {
+            "type": "hidden"
+          },
+          "lga": {
+            "name": "Local Government Area",
+            "type": "hidden"
+          },
+          "suburb": {
+            "name": "Suburb",
+            "type": "hidden"
+          },
+          "station_id": {
+            "type": "HIDDEN"
+          },
+          "name": {
+            "type": "HIDDEN"
+          },
+          "road_type": {
+            "name": "Road Type"
+          },
+          "primary_direction": {
+            "type": "HIDDEN"
+          },
+          "unclassified_count": {
+            "name": "Unclassified Vehicles count",
+            "colorBins": [0, 1000, 5000, 10000, 20000, 30000, 50000, 70000]
+          },
+          "all_vehicles_count": {
+            "name": "All Vehicles count",
+            "colorBins": [0, 1000, 5000, 10000, 20000, 30000, 50000, 70000]
+          },
+          "light_vehicles_count": {
+            "name": "Light Vehicles count",
+            "colorBins": [0, 1000, 5000, 10000, 20000, 30000, 50000, 70000]
+          },
+          "heavy_vehicles_count": {
+            "name": "Heavy Vehicles count",
+            "colorBins": [0, 1000, 5000, 10000, 20000]
+          }
+        }
+      },
+      "infoSectionOrder": [
+        "Data Description",
+        "Data Updates",
+        "Data Supplier and Processing",
+        "Disclaimer"
+      ],
+      "info": [
+        {
+          "name": "Data Description",
+          "content": "<p>This is a NSW map of average daily traffic volumes at different monitoring stations, recorded in average number of vehicles per day across each reported year. Data displayed is for the primary direction of travel specified (east-west or north-south) and is in annual timesteps from 2015 onwards.</p> <p>Use the time slider bar at the bottom to explore how traffic volumes and the location of traffic monitoring stations change over time. A number of different display variables can also be selected in the legend panel: road type, all vehicles, heavy vehicles, light vehicles or unclassified vehicles.</p> <p>In the context of Electric Vehicle charging infrastructure planning, this is a critical variable that indicates potential demand for charging services, dictated by passing road traffic.</p> <p>Click on a monitoring station to reveal the following information:</p> <ul> <li><strong>Station name</strong></li> <li><strong>Station ID: </strong>Code used to identify specific monitoring station</li> <li><strong>LGA; Suburb:</strong> Local Government Area and suburb in which the monitoring station is located</li> <li><strong>Road type:</strong> Motorway, Arterial road, Sub-Arterial Road, Distributor Road, Primary Road</li> <li><strong>Primary direction captured:</strong> Direction of travel presented in the data</li> <li><strong>Vehicle counts:</strong></li> <ul> <li><strong>All vehicles: </strong>Total number of vehicles of any type</li> <li><strong>Light vehicles:</strong> This tends to be passenger vehicles.</li> <li><strong>Heavy vehicles:</strong> This tends to be commercial vehicles.</li> <li><strong>Unclassified vehicles:</strong> Some stations do not classify vehicles by weight and thus this is generally the same as &ldquo;All vehicles&rdquo; for these stations.</li> </ul> <li><strong>Daily History:</strong> A chart is provided for the daily variations underpinning the average figures. <u>Click &ldquo;Expand&rdquo; to add to a larger chart to compare monitoring stations and download graphed data.</u> Select in the legend which directions of travel are graphed (primary direction and/or opposite direction).</li> </ul>"
+        },
+        {
+          "name": "Data Updates",
+          "content": "<p>Continually updated from API.</p>"
+        },
+        {
+          "name": "Data Supplier and processing",
+          "content": "<p>The data is served directly from the Transport NSW API. Data processing for visualisation is managed by the Institute of Sustainable Futures at the University of Technology Sydney (UTS).</p>"
+        },
+        {
+          "name": "Disclaimer",
+          "content": "<p>Although every effort has been made to ensure the quality of the data, neither the Institute for Sustainable Futures nor the NSW Roads and Maritime Services can guarantee the accuracy of the data and does not accept responsibility for any consequences arising from its use.</p>"
+        }
+      ],
+      "featureInfoTemplate": {
+        "template": "<h4 style=\"margin-top:10px;margin-bottom:5px;\">{{name}}</h4>\n        Station ID: {{station_id}}<br/>\n        LGA: {{lga}}<br/>\n        SUBURB: {{suburb}}<br/>\n        ROAD TYPE: {{road_type}}<br/>\n        PRIMARY DIRECTION CAPTURED: {{primary_direction}}<br/>\n\n        <h4 style=\"margin-top:10px;margin-bottom:5px;\">{{year}} Average Daily Traffic Counts - Both Directions</h4>\n        Light Vehicles Count: {{light_vehicles_count}}<br/>\n        Heavy Vehicles Count: {{heavy_vehicles_count}}<br/>\n        All Vehicles Count (light + heavy): {{all_vehicles_count}}<br/>\n\n        Unclassified Count: {{unclassified_count}}<br/>\n        <br/><br/>\n\n  <h5 style=\"margin-top:5px;margin-bottom:5px;\">Daily History - Primary Direction</h5>\n  <chart\n    id=\"{{name}}\"\n    title=\"{{name}}\"\n    sources=\"https://api.transport.nsw.gov.au/v1/roads/spatial?format=csv&q=%0A%20%20%20%20%20SELECT%20TO_CHAR(HOURLY.DATE%20%3A%3A%20DATE%2C%20'YYYY-MM-DD')%20AS%20DATE%2C%0A%20%20%20%20%20CASE%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'0'%20THEN%20'BOTH'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'1'%20THEN%20'NORTH'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'3'%20THEN%20'EAST'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'5'%20THEN%20'SOUTH'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'7'%20THEN%20'WEST'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'9'%20THEN%20'NORTHBOUND-SOUTHBOUND'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'10'%20THEN%20'EASTBOUND-WESTBOUND'%0A%20%20%20%20END%20AS%20PRIMARY_DIRECTION%2C%0A%20%20%20%20SUM(CASE%20TRAFFIC_DIRECTION_SEQ%20WHEN%20'0'%20THEN%20DAILY_TOTAL%20ELSE%200%20END)%20AS%20PRIMARY_DIRECTION_COUNT%2C%0A%20%20%20%20SUM(CASE%20TRAFFIC_DIRECTION_SEQ%20WHEN%20'1'%20THEN%20DAILY_TOTAL%20ELSE%200%20END)%20AS%20OPPOSITE_DIRECTION__COUNT%0A%20%20%20%20FROM%20road_traffic_counts_station_reference%20REF%0A%20%20%20%20%20%20JOIN%20road_traffic_counts_hourly_permanent%20HOURLY%20ON%20REF.STATION_KEY%3DHOURLY.STATION_KEY%0A%20%20%20%20%20%20WHERE%20DATE%20BETWEEN%20'2019-01-01'%20AND%20CURRENT_DATE%0A%20%20%20%20 {{#terria.urlEncodeComponent}}AND STATION_ID='{{station_id}}' GROUP BY HOURLY.DATE,DIRECTION_SEQ{{/terria.urlEncodeComponent}},https://api.transport.nsw.gov.au/v1/roads/spatial?format=csv&q=%0A%20%20%20%20%20SELECT%20TO_CHAR(HOURLY.DATE%20%3A%3A%20DATE%2C%20'YYYY-MM-DD')%20AS%20DATE%2C%0A%20%20%20%20SUM(CASE%20CLASSIFICATION_SEQ%20WHEN%20'0'%20THEN%20DAILY_TOTAL%20ELSE%200%20END)%20AS%20UNCLASSIFIED_COUNT%2C%0A%20%20%20%20SUM(CASE%20CLASSIFICATION_SEQ%20WHEN%20'1'%20THEN%20DAILY_TOTAL%20ELSE%200%20END)%20AS%20ALL_VEHICLES_COUNT%2C%0A%20%20%20%20SUM(CASE%20CLASSIFICATION_SEQ%20WHEN%20'2'%20THEN%20DAILY_TOTAL%20ELSE%200%20END)%20AS%20LIGHT_VEHICLES_COUNT%2C%0A%20%20%20%20SUM(CASE%20CLASSIFICATION_SEQ%20WHEN%20'3'%20THEN%20DAILY_TOTAL%20ELSE%200%20END)%20AS%20HEAVY_VEHICLES_COUNT%0A%20%20%20%20FROM%20road_traffic_counts_station_reference%20REF%0A%20%20%20%20%20%20JOIN%20road_traffic_counts_hourly_permanent%20HOURLY%20ON%20REF.STATION_KEY%3DHOURLY.STATION_KEY%0A%20%20%20%20%20%20WHERE%20DATE%20BETWEEN%20'2019-01-01'%20AND%20CURRENT_DATE%0A%20%20%20%20 {{#terria.urlEncodeComponent}}AND STATION_ID='{{station_id}}' GROUP BY HOURLY.DATE{{/terria.urlEncodeComponent}}\"\n    source-names='Chart By Traffic Direction, Chart By Vehicle Type'\n    downloads=\"proxy/https://api.transport.nsw.gov.au/v1/roads/spatial?format=csv&q=%0A%20%20%20%20%20SELECT%20TO_CHAR(HOURLY.DATE%20%3A%3A%20DATE%2C%20'YYYY-MM-DD')%20AS%20DATE%2C%0A%20%20%20%20%20CASE%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'0'%20THEN%20'BOTH'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'1'%20THEN%20'NORTH'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'3'%20THEN%20'EAST'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'5'%20THEN%20'SOUTH'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'7'%20THEN%20'WEST'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'9'%20THEN%20'NORTHBOUND-SOUTHBOUND'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'10'%20THEN%20'EASTBOUND-WESTBOUND'%0A%20%20%20%20END%20AS%20PRIMARY_DIRECTION%2C%0A%20%20%20%20SUM(CASE%20TRAFFIC_DIRECTION_SEQ%20WHEN%20'0'%20THEN%20DAILY_TOTAL%20ELSE%200%20END)%20AS%20PRIMARY_DIRECTION_COUNT%2C%0A%20%20%20%20SUM(CASE%20TRAFFIC_DIRECTION_SEQ%20WHEN%20'1'%20THEN%20DAILY_TOTAL%20ELSE%200%20END)%20AS%20OPPOSITE_DIRECTION__COUNT%0A%20%20%20%20FROM%20road_traffic_counts_station_reference%20REF%0A%20%20%20%20%20%20JOIN%20road_traffic_counts_hourly_permanent%20HOURLY%20ON%20REF.STATION_KEY%3DHOURLY.STATION_KEY%0A%20%20%20%20%20%20WHERE%20DATE%20BETWEEN%20'2019-01-01'%20AND%20CURRENT_DATE%0A%20%20%20%20 {{#terria.urlEncodeComponent}}AND STATION_ID='{{station_id}}' GROUP BY HOURLY.DATE,DIRECTION_SEQ{{/terria.urlEncodeComponent}}\"\n    download-names='Current chart'\n  ></chart>\n  "
+      }
+    }
+  ]
+}

--- a/test/samples/v7/power-generation.json
+++ b/test/samples/v7/power-generation.json
@@ -74,6 +74,51 @@
           "content": "Australian Energy Market Operator (AEMO) is the data custodian for Generation & Load data sets, available on AEMO’s website. <br/><br/>AREMI is displaying the data under AEMO’s licencing and copyright conditions detailed below. <br/><br/>The data is provided for information only and is not intended for commercial use. AEMO does not guarantee the accuracy of the data or its availability at all times.<br/><br/>AEMO, or its licensors, are the owners of all copyright and all other intellectual property rights in the contents of the AEMO website (including text and images). Users may only use such contents for personal use or as authorised by AEMO. Here are the details of the AEMO’s copyright permissions: <br/><br/>AEMO Material comprises documents, reports, sound and video recordings and any other material created by or on behalf of AEMO and made publicly available by AEMO. All AEMO Material is protected by copyright under Australian law. A publication is protected even if it does not display the © symbol.  <br/><br/>In addition to the uses permitted under copyright laws, AEMO confirms its general permission for anyone to use AEMO Material for any purpose, but only with accurate and appropriate attribution of the relevant AEMO Material and AEMO as its author. There is no need to obtain specific permission to use AEMO Material in this way. Confidential documents and any reports commissioned by another person or body who may own the copyright in them and NOT AEMO Material, and these permissions do not apply to those documents. <br/><br/>More information on conditions of use of AEMO generated data and information is available on the AEMO website: [http://aemo.com.au/About-AEMO/Legal-Notices](http://aemo.com.au/About-AEMO/Legal-Notices)"
         }
       ]
+    },
+    {
+      "id": "54a553b5",
+      "name": "All generation types 2",
+      "url": "https://services.aremi.data61.io/aemo/v6/csv/all",
+      "type": "csv",
+      "tableStyle": {
+        "colorMap": [
+          {
+            "color": "rgba(0,0,200,1.0)",
+            "offset": 0
+          },
+          {
+            "color": "rgba(0,255,255,1.00)",
+            "offset": 0.25
+          },
+          {
+            "color": "rgba(0,200,0,1.00)",
+            "offset": 0.5
+          },
+          {
+            "color": "rgba(255,255,0,1.00)",
+            "offset": 0.75
+          },
+          {
+            "color": "rgba(200,0,0,1.00)",
+            "offset": 1
+          }
+        ]
+      }
+    },
+    {
+      "id": "54a553b6",
+      "name": "All generation types 3",
+      "url": "https://services.aremi.data61.io/aemo/v6/csv/all",
+      "type": "csv",
+      "tableStyle": {
+        "colorMap": [
+          "rgba(0,0,200,1.0)",
+          "rgba(0,255,255,1.00)",
+          "rgba(0,200,0,1.00)",
+          "rgba(255,255,0,1.00)",
+          "rgba(200,0,0,1.00)"
+        ]
+      }
     }
   ]
 }

--- a/test/samples/v8/csv-styles.json
+++ b/test/samples/v8/csv-styles.json
@@ -1,0 +1,116 @@
+{
+  "catalog": [
+    {
+      "type": "csv",
+      "name": "Average Daily Traffic Volume",
+      "info": [
+        {
+          "name": "Data Description",
+          "content": "<p>This is a NSW map of average daily traffic volumes at different monitoring stations, recorded in average number of vehicles per day across each reported year. Data displayed is for the primary direction of travel specified (east-west or north-south) and is in annual timesteps from 2015 onwards.</p> <p>Use the time slider bar at the bottom to explore how traffic volumes and the location of traffic monitoring stations change over time. A number of different display variables can also be selected in the legend panel: road type, all vehicles, heavy vehicles, light vehicles or unclassified vehicles.</p> <p>In the context of Electric Vehicle charging infrastructure planning, this is a critical variable that indicates potential demand for charging services, dictated by passing road traffic.</p> <p>Click on a monitoring station to reveal the following information:</p> <ul> <li><strong>Station name</strong></li> <li><strong>Station ID: </strong>Code used to identify specific monitoring station</li> <li><strong>LGA; Suburb:</strong> Local Government Area and suburb in which the monitoring station is located</li> <li><strong>Road type:</strong> Motorway, Arterial road, Sub-Arterial Road, Distributor Road, Primary Road</li> <li><strong>Primary direction captured:</strong> Direction of travel presented in the data</li> <li><strong>Vehicle counts:</strong></li> <ul> <li><strong>All vehicles: </strong>Total number of vehicles of any type</li> <li><strong>Light vehicles:</strong> This tends to be passenger vehicles.</li> <li><strong>Heavy vehicles:</strong> This tends to be commercial vehicles.</li> <li><strong>Unclassified vehicles:</strong> Some stations do not classify vehicles by weight and thus this is generally the same as &ldquo;All vehicles&rdquo; for these stations.</li> </ul> <li><strong>Daily History:</strong> A chart is provided for the daily variations underpinning the average figures. <u>Click &ldquo;Expand&rdquo; to add to a larger chart to compare monitoring stations and download graphed data.</u> Select in the legend which directions of travel are graphed (primary direction and/or opposite direction).</li> </ul>"
+        },
+        {
+          "name": "Data Updates",
+          "content": "<p>Continually updated from API.</p>"
+        },
+        {
+          "name": "Data Supplier and processing",
+          "content": "<p>The data is served directly from the Transport NSW API. Data processing for visualisation is managed by the Institute of Sustainable Futures at the University of Technology Sydney (UTS).</p>"
+        },
+        {
+          "name": "Disclaimer",
+          "content": "<p>Although every effort has been made to ensure the quality of the data, neither the Institute for Sustainable Futures nor the NSW Roads and Maritime Services can guarantee the accuracy of the data and does not accept responsibility for any consequences arising from its use.</p>"
+        }
+      ],
+      "infoSectionOrder": [
+        "Data Description",
+        "Data Updates",
+        "Data Supplier and Processing",
+        "Disclaimer"
+      ],
+      "url": "https://api.transport.nsw.gov.au/v1/roads/spatial?format=csv&q=%0A%20%20%20%20%20%20SELECT%0A%20%20%20%20%20%20%20%20REF.STATION_ID%2C%0A%20%20%20%20%20%20%20%20NAME%2C%0A%20%20%20%20%20%20%20%20LGA%2C%0A%20%20%20%20%20%20%20%20SUBURB%2C%0A%20%20%20%20%20%20%20%20CASE%20VEHICLE_CLASSIFIER%20WHEN%200%20THEN%20true%20ELSE%20false%20END%20AS%20HAS_VEHICLE_CLASSIFIER%2C%0A%20%20%20%20%20%20%20%20ROAD_FUNCTIONAL_HIERARCHY%20AS%20ROAD_TYPE%2C%0A%20%20%20%20%20%20%20%20WGS84_LATITUDE%20AS%20LATITUDE%2C%0A%20%20%20%20%20%20%20%20WGS84_LONGITUDE%20AS%20LONGITUDE%2C%0A%20%20%20%20%20%20%20%20YEAR%2C%0A%20%20%20%20%20%20%20%20CASE%0A%20%20%20%20%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'0'%20THEN%20'BOTH'%0A%20%20%20%20%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'1'%20THEN%20'NORTH'%0A%20%20%20%20%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'3'%20THEN%20'EAST'%0A%20%20%20%20%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'5'%20THEN%20'SOUTH'%0A%20%20%20%20%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'7'%20THEN%20'WEST'%0A%20%20%20%20%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'9'%20THEN%20'NORTH%20TO%20SOUTH'%0A%20%20%20%20%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'10'%20THEN%20'EAST%20TO%20WEST'%0A%20%20%20%20%20%20%20%20END%20AS%20PRIMARY_DIRECTION%2C%0A%20%20%20%20%20%20%20%20SUM(CASE%20CLASSIFICATION_TYPE%20WHEN%20'UNCLASSIFIED'%20THEN%20TRAFFIC_COUNT%20ELSE%200%20END)%20AS%20UNCLASSIFIED_COUNT%2C%0A%20%20%20%20%20%20%20%20SUM(CASE%20CLASSIFICATION_TYPE%20WHEN%20'ALL%20VEHICLES'%20THEN%20TRAFFIC_COUNT%20ELSE%200%20END)%20AS%20ALL_VEHICLES_COUNT%2C%0A%20%20%20%20%20%20%20%20SUM(CASE%20CLASSIFICATION_TYPE%20WHEN%20'LIGHT%20VEHICLES'%20THEN%20TRAFFIC_COUNT%20ELSE%200%20END)%20AS%20LIGHT_VEHICLES_COUNT%2C%0A%20%20%20%20%20%20%20%20SUM(CASE%20CLASSIFICATION_TYPE%20WHEN%20'HEAVY%20VEHICLES'%20THEN%20TRAFFIC_COUNT%20ELSE%200%20END)%20AS%20HEAVY_VEHICLES_COUNT%0A%20%20%20%20%20%20FROM%20road_traffic_counts_station_reference%20REF%0A%20%20%20%20%20%20JOIN%20road_traffic_counts_yearly_summary%20SUMM%20ON%20REF.STATION_KEY%3DSUMM.STATION_KEY%0A%20%20%20%20%20%20WHERE%20YEAR%20IN%20('2015'%2C'2016'%2C'2017'%2C'2018'%2C'2019')%0A%20%20%20%20%20%20%20%20AND%20PERIOD%3D'ALL%20DAYS'%0A%20%20%20%20%20%20%20%20AND%20TRAFFIC_DIRECTION_SEQ%20IN%20('0'%2C%20'1')%0A%20%20%20%20%20%20GROUP%20BY%20REF.STATION_ID%2CVEHICLE_CLASSIFIER%2CNAME%2CLGA%2CSUBURB%2CWGS84_LATITUDE%2CWGS84_LONGITUDE%2CYEAR%2CROAD_FUNCTIONAL_HIERARCHY%2CDIRECTION_SEQ%0A%20%20",
+      "columns": [
+        {
+          "name": "has_vehicle_classifier",
+          "type": "hidden"
+        },
+        {
+          "name": "lga",
+          "type": "hidden",
+          "title": "Local Government Area"
+        },
+        {
+          "name": "suburb",
+          "type": "hidden",
+          "title": "Suburb"
+        },
+        {
+          "name": "station_id",
+          "type": "hidden"
+        },
+        {
+          "name": "name",
+          "type": "hidden"
+        },
+        {
+          "name": "road_type",
+          "title": "Road Type"
+        },
+        {
+          "name": "primary_direction",
+          "type": "hidden"
+        },
+        {
+          "name": "unclassified_count",
+          "title": "Unclassified Vehicles count"
+        },
+        {
+          "name": "all_vehicles_count",
+          "title": "All Vehicles count"
+        },
+        {
+          "name": "light_vehicles_count",
+          "title": "Light Vehicles count"
+        },
+        {
+          "name": "heavy_vehicles_count",
+          "title": "Heavy Vehicles count"
+        }
+      ],
+      "styles": [
+        {
+          "id": "unclassified_count",
+          "color": {
+            "binMaximums": [0, 1000, 5000, 10000, 20000, 30000, 50000, 70000]
+          }
+        },
+        {
+          "id": "all_vehicles_count",
+          "color": {
+            "binMaximums": [0, 1000, 5000, 10000, 20000, 30000, 50000, 70000]
+          }
+        },
+        {
+          "id": "light_vehicles_count",
+          "color": {
+            "binMaximums": [0, 1000, 5000, 10000, 20000, 30000, 50000, 70000]
+          }
+        },
+        {
+          "id": "heavy_vehicles_count",
+          "color": {
+            "binMaximums": [0, 1000, 5000, 10000, 20000]
+          }
+        }
+      ],
+      "defaultStyle": {
+        "color": {
+          "colorPalette": "YlOrBr"
+        }
+      },
+      "featureInfoTemplate": {
+        "template": "<h4 style=\"margin-top:10px;margin-bottom:5px;\">{{name}}</h4>\n        Station ID: {{station_id}}<br/>\n        LGA: {{lga}}<br/>\n        SUBURB: {{suburb}}<br/>\n        ROAD TYPE: {{road_type}}<br/>\n        PRIMARY DIRECTION CAPTURED: {{primary_direction}}<br/>\n\n        <h4 style=\"margin-top:10px;margin-bottom:5px;\">{{year}} Average Daily Traffic Counts - Both Directions</h4>\n        Light Vehicles Count: {{light_vehicles_count}}<br/>\n        Heavy Vehicles Count: {{heavy_vehicles_count}}<br/>\n        All Vehicles Count (light + heavy): {{all_vehicles_count}}<br/>\n\n        Unclassified Count: {{unclassified_count}}<br/>\n        <br/><br/>\n\n  <h5 style=\"margin-top:5px;margin-bottom:5px;\">Daily History - Primary Direction</h5>\n  <chart\n    id=\"{{name}}\"\n    title=\"{{name}}\"\n    sources=\"https://api.transport.nsw.gov.au/v1/roads/spatial?format=csv&q=%0A%20%20%20%20%20SELECT%20TO_CHAR(HOURLY.DATE%20%3A%3A%20DATE%2C%20'YYYY-MM-DD')%20AS%20DATE%2C%0A%20%20%20%20%20CASE%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'0'%20THEN%20'BOTH'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'1'%20THEN%20'NORTH'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'3'%20THEN%20'EAST'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'5'%20THEN%20'SOUTH'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'7'%20THEN%20'WEST'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'9'%20THEN%20'NORTHBOUND-SOUTHBOUND'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'10'%20THEN%20'EASTBOUND-WESTBOUND'%0A%20%20%20%20END%20AS%20PRIMARY_DIRECTION%2C%0A%20%20%20%20SUM(CASE%20TRAFFIC_DIRECTION_SEQ%20WHEN%20'0'%20THEN%20DAILY_TOTAL%20ELSE%200%20END)%20AS%20PRIMARY_DIRECTION_COUNT%2C%0A%20%20%20%20SUM(CASE%20TRAFFIC_DIRECTION_SEQ%20WHEN%20'1'%20THEN%20DAILY_TOTAL%20ELSE%200%20END)%20AS%20OPPOSITE_DIRECTION__COUNT%0A%20%20%20%20FROM%20road_traffic_counts_station_reference%20REF%0A%20%20%20%20%20%20JOIN%20road_traffic_counts_hourly_permanent%20HOURLY%20ON%20REF.STATION_KEY%3DHOURLY.STATION_KEY%0A%20%20%20%20%20%20WHERE%20DATE%20BETWEEN%20'2019-01-01'%20AND%20CURRENT_DATE%0A%20%20%20%20 {{#terria.urlEncodeComponent}}AND STATION_ID='{{station_id}}' GROUP BY HOURLY.DATE,DIRECTION_SEQ{{/terria.urlEncodeComponent}},https://api.transport.nsw.gov.au/v1/roads/spatial?format=csv&q=%0A%20%20%20%20%20SELECT%20TO_CHAR(HOURLY.DATE%20%3A%3A%20DATE%2C%20'YYYY-MM-DD')%20AS%20DATE%2C%0A%20%20%20%20SUM(CASE%20CLASSIFICATION_SEQ%20WHEN%20'0'%20THEN%20DAILY_TOTAL%20ELSE%200%20END)%20AS%20UNCLASSIFIED_COUNT%2C%0A%20%20%20%20SUM(CASE%20CLASSIFICATION_SEQ%20WHEN%20'1'%20THEN%20DAILY_TOTAL%20ELSE%200%20END)%20AS%20ALL_VEHICLES_COUNT%2C%0A%20%20%20%20SUM(CASE%20CLASSIFICATION_SEQ%20WHEN%20'2'%20THEN%20DAILY_TOTAL%20ELSE%200%20END)%20AS%20LIGHT_VEHICLES_COUNT%2C%0A%20%20%20%20SUM(CASE%20CLASSIFICATION_SEQ%20WHEN%20'3'%20THEN%20DAILY_TOTAL%20ELSE%200%20END)%20AS%20HEAVY_VEHICLES_COUNT%0A%20%20%20%20FROM%20road_traffic_counts_station_reference%20REF%0A%20%20%20%20%20%20JOIN%20road_traffic_counts_hourly_permanent%20HOURLY%20ON%20REF.STATION_KEY%3DHOURLY.STATION_KEY%0A%20%20%20%20%20%20WHERE%20DATE%20BETWEEN%20'2019-01-01'%20AND%20CURRENT_DATE%0A%20%20%20%20 {{#terria.urlEncodeComponent}}AND STATION_ID='{{station_id}}' GROUP BY HOURLY.DATE{{/terria.urlEncodeComponent}}\"\n    source-names='Chart By Traffic Direction, Chart By Vehicle Type'\n    downloads=\"proxy/https://api.transport.nsw.gov.au/v1/roads/spatial?format=csv&q=%0A%20%20%20%20%20SELECT%20TO_CHAR(HOURLY.DATE%20%3A%3A%20DATE%2C%20'YYYY-MM-DD')%20AS%20DATE%2C%0A%20%20%20%20%20CASE%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'0'%20THEN%20'BOTH'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'1'%20THEN%20'NORTH'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'3'%20THEN%20'EAST'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'5'%20THEN%20'SOUTH'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'7'%20THEN%20'WEST'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'9'%20THEN%20'NORTHBOUND-SOUTHBOUND'%0A%20%20%20%20%20%20WHEN%20DIRECTION_SEQ%3D'10'%20THEN%20'EASTBOUND-WESTBOUND'%0A%20%20%20%20END%20AS%20PRIMARY_DIRECTION%2C%0A%20%20%20%20SUM(CASE%20TRAFFIC_DIRECTION_SEQ%20WHEN%20'0'%20THEN%20DAILY_TOTAL%20ELSE%200%20END)%20AS%20PRIMARY_DIRECTION_COUNT%2C%0A%20%20%20%20SUM(CASE%20TRAFFIC_DIRECTION_SEQ%20WHEN%20'1'%20THEN%20DAILY_TOTAL%20ELSE%200%20END)%20AS%20OPPOSITE_DIRECTION__COUNT%0A%20%20%20%20FROM%20road_traffic_counts_station_reference%20REF%0A%20%20%20%20%20%20JOIN%20road_traffic_counts_hourly_permanent%20HOURLY%20ON%20REF.STATION_KEY%3DHOURLY.STATION_KEY%0A%20%20%20%20%20%20WHERE%20DATE%20BETWEEN%20'2019-01-01'%20AND%20CURRENT_DATE%0A%20%20%20%20 {{#terria.urlEncodeComponent}}AND STATION_ID='{{station_id}}' GROUP BY HOURLY.DATE,DIRECTION_SEQ{{/terria.urlEncodeComponent}}\"\n    download-names='Current chart'\n  ></chart>\n  "
+      },
+      "shareKeys": ["Root Group/Average Daily Traffic Volume"]
+    }
+  ]
+}

--- a/test/samples/v8/power-generation.json
+++ b/test/samples/v8/power-generation.json
@@ -103,6 +103,40 @@
         "name": "{{DUID}} - {{Station Name}}: {{Current % of Max Cap}}%",
         "template": "<h3>{{Station Name}} ({{DUID}})</h3><p><strong>{{Participant}}</strong><div><strong>{{Current Output (MW)}}MW</strong> at {{Most Recent Output Time (AEST)}}</div><div><strong>{{Current % of Reg Cap}}%</strong> of {{Reg Cap (MW)}}MW registered capacity</div><div><strong>{{Current % of Max Cap}}%</strong> of {{Max Cap (MW)}}MW maximum capacity</div></p><table>  <tbody>    <tr>      <td>Category</td>      <td class='strong'>{{Category}}</td>    </tr>    <tr>      <td>Classification</td>      <td class='strong'>{{Classification}}</td>    </tr>    <tr>      <td>Fuel Source</td>      <td class='strong'>{{Fuel Source - Primary}} ({{Fuel Source - Descriptor}})</td>    </tr>    <tr>      <td>Technology Type</td>      <td class='strong'>{{Technology Type - Primary}} ({{Technology Type - Descriptor}})</td>    </tr>    <tr>      <td>Physical Unit No.</td>      <td class='strong'>{{Physical Unit No_}}</td>    </tr>    <tr>      <td>Unit Size (MW)</td>      <td class='strong'>{{Unit Size (MW)}}</td>    </tr>    <tr>      <td>Aggregation</td>      <td class='strong'>{{Aggregation}}</td>    </tr>    <tr>      <td>Region</td>      <td class='strong'>{{Region}}</td>    </tr>    <tr><td>Power generation</td><td><chart id='{{DUID}}' title='{{Station Name}} ({{DUID}})' poll-seconds='300' poll-replace='true' sources='https://services.aremi.data61.io/aemo/v6/duidcsv/{{#terria.urlEncodeComponent}}{{DUID}}{{/terria.urlEncodeComponent}}?offset=1D,https://services.aremi.data61.io/aemo/v6/duidcsv/{{#terria.urlEncodeComponent}}{{DUID}}{{/terria.urlEncodeComponent}}?offset=7D,https://services.aremi.data61.io/aemo/v6/duidcsv/{{#terria.urlEncodeComponent}}{{DUID}}{{/terria.urlEncodeComponent}}?offset=1M,https://services.aremi.data61.io/aemo/v6/duidcsv/{{#terria.urlEncodeComponent}}{{DUID}}{{/terria.urlEncodeComponent}}?offset=3M' source-names='1d,7d,1m,3m' downloads='https://services.aremi.data61.io/aemo/v6/duidcsv/{{#terria.urlEncodeComponent}}{{DUID}}{{/terria.urlEncodeComponent}}?offset=7D,https://services.aremi.data61.io/aemo/v6/duidcsv/{{#terria.urlEncodeComponent}}{{DUID}}{{/terria.urlEncodeComponent}}?offset=1M,https://services.aremi.data61.io/aemo/v6/duidcsv/{{#terria.urlEncodeComponent}}{{DUID}}{{/terria.urlEncodeComponent}}?offset=3M,https://services.aremi.data61.io/aemo/v6/duidcsv/{{#terria.urlEncodeComponent}}{{DUID}}{{/terria.urlEncodeComponent}}' download-names='7d,1m,3m,All available' preview-x-label='Last 24 hours' column-names='Time,Power Generation' column-units='Date,MW'></chart></td></tr>  </tbody></table>"
       }
+    },
+    {
+      "type": "csv",
+      "name": "All generation types 2",
+      "id": "54a553b5",
+      "url": "https://services.aremi.data61.io/aemo/v6/csv/all",
+      "defaultStyle": {
+        "color": {
+          "binColors": [
+            "rgba(0,0,200,1.0)",
+            "rgba(0,255,255,1.00)",
+            "rgba(0,200,0,1.00)",
+            "rgba(255,255,0,1.00)",
+            "rgba(200,0,0,1.00)"
+          ]
+        }
+      }
+    },
+    {
+      "type": "csv",
+      "name": "All generation types 3",
+      "id": "54a553b6",
+      "url": "https://services.aremi.data61.io/aemo/v6/csv/all",
+      "defaultStyle": {
+        "color": {
+          "binColors": [
+            "rgba(0,0,200,1.0)",
+            "rgba(0,255,255,1.00)",
+            "rgba(0,200,0,1.00)",
+            "rgba(255,255,0,1.00)",
+            "rgba(200,0,0,1.00)"
+          ]
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
In v7 `colorMap` can be three things:
- String, eg. 'red-black'
- Array of strings, eg. ['red', 'black']
- Array of objects with the properties 'color' and 'offset', eg. [{color: 'red', offset: 0}, ...].
  - v8 only supports array of strings, so 'offset' is discarded

This PR adds support for:

- `colorMap` "array of objects with the properties 'color' and 'offset'"
- `colorPalette`
- `colorBins`
- column `name` as `title`
- column `styles` support
- fix column `type='hidden'`

